### PR TITLE
Add more missing APIs to satisfy qtwebengine

### DIFF
--- a/libdbus-1.c
+++ b/libdbus-1.c
@@ -121,3 +121,10 @@ void* dbus_validate_interface() { return 0; }
 void* dbus_validate_error_name() { return 0; }
 void* dbus_validate_bus_name() { return 0; }
 void* dbus_validate_utf8() { return 0; }
+void* dbus_connection_set_dispatch_status_function() { return 0; }
+void* dbus_message_type_to_string() { return 0; }
+void* dbus_connection_try_register_fallback() { return 0; }
+void* dbus_message_set_member() { return 0; }
+void* dbus_get_version() { return 0; }
+void* dbus_message_get_serial() { return 0; }
+void* dbus_message_get_reply_serial() { return 0; }

--- a/libdbus-1.c.bak
+++ b/libdbus-1.c.bak
@@ -121,3 +121,10 @@ void dbus_validate_interface() {}
 void dbus_validate_error_name() {}
 void dbus_validate_bus_name() {}
 void dbus_validate_utf8() {}
+void dbus_connection_set_dispatch_status_function() {}
+void dbus_message_type_to_string() {}
+void dbus_connection_try_register_fallback() {}
+void dbus_message_set_member() {}
+void dbus_get_version() {}
+void dbus_message_get_serial() {}
+void dbus_message_get_reply_serial() {}


### PR DESCRIPTION
QtWebEngine 6.8.2 fails its link stage with following error:

```
FAILED: lib64/libQt6WebEngineCore.so.6.8.2
: && /var/tmp/portage/dev-qt/qtwebengine-6.8.2-r1/work/qtwebengine-everywhere-src-6.8.2_build/linker_ulimit.sh /usr/lib/ccache/bin/aarch64-unknown-linux-gnu-g++ -fPIC -O2 -pipe  -Wl,-O1 -Wl,--as-needed   -Wl,--no-undefined -Wl,--version-script,/var/tmp/portage/dev-qt/qtwebengine-6.8.2-r1/work/qtwebengine-everywhere-src-6.8.2_build/src/core/api/WebEngineCore.version @/var/tmp/portage/dev-qt/qtwebengine-6.8.2-r1/work/qtwebengine-everywhere-src-6.8.2_build/src/core/RelWithDebInfo/aarch64/QtWebEngineCore_objects.rsp -Wl,--gc-sections -Wl,--enable-new-dtags -shared -Wl,-soname,libQt6WebEngineCore.so.6 -o lib64/libQt6WebEngineCore.so.6.8.2 src/core/api/CMakeFiles/WebEngineCore.dir/Unity/unity_1_cxx.cxx.o src/core/api/CMakeFiles/WebEngineCore.dir/Unity/unity_0_cxx.cxx.o  -Wl,-rpath,:::::::  /usr/lib64/libQt6WebChannel.so.6.8.2  -Wl,--start-group @/var/tmp/portage/dev-qt/qtwebengine-6.8.2-r1/work/qtwebengine-everywhere-src-6.8.2_build/src/core/RelWithDebInfo/aarch64/QtWebEngineCore_archives.rsp -Wl,--end-group  -Wl,--no-fatal-warnings @/var/tmp/portage/dev-qt/qtwebengine-6.8.2-r1/work/qtwebengine-everywhere-src-6.8.2_build/src/core/RelWithDebInfo/aarch64/QtWebEngineCore_ldir.rsp @/var/tmp/portage/dev-qt/qtwebengine-6.8.2-r1/work/qtwebengine-everywhere-src-6.8.2_build/src/core/RelWithDebInfo/aarch64/QtWebEngineCore_libs.rsp -Wl,--no-fatal-warnings /usr/lib64/libQt6Quick.so.6.8.2  /usr/lib64/libQt6OpenGL.so.6.8.2  /usr/lib64/libQt6Gui.so.6.8.2  /usr/lib64/libGLX.so  /usr/lib64/libOpenGL.so  /usr/lib64/libxkbcommon.so  /usr/lib64/libQt6QmlMeta.so.6.8.2  /usr/lib64/libQt6QmlModels.so.6.8.2  /usr/lib64/libQt6QmlWorkerScript.so.6.8.2  /usr/lib64/libQt6Qml.so.6.8.2  /usr/lib64/libQt6Network.so.6.8.2  /usr/lib64/libQt6Core.so.6.8.2 && : 
/usr/lib/gcc/aarch64-unknown-linux-gnu/14/../../../../aarch64-unknown-linux-gnu/bin/ld: /var/tmp/portage/dev-qt/qtwebengine-6.8.2-r1/work/qtwebengine-everywhere-src-6.8.2_build/src/core/RelWithDebInfo/aarch64/obj/dbus/dbus/bus.o: in function `dbus::Bus::SetUpAsyncOperations()':
bus.cc:(.text._ZN4dbus3Bus20SetUpAsyncOperationsEv+0xe8): undefined reference to `dbus_connection_set_dispatch_status_function'
/usr/lib/gcc/aarch64-unknown-linux-gnu/14/../../../../aarch64-unknown-linux-gnu/bin/ld: /var/tmp/portage/dev-qt/qtwebengine-6.8.2-r1/work/qtwebengine-everywhere-src-6.8.2_build/src/core/RelWithDebInfo/aarch64/obj/dbus/dbus/bus.o: in function `dbus::Bus::SendWithReplyAndBlock(DBusMessage*, int)':
bus.cc:(.text._ZN4dbus3Bus21SendWithReplyAndBlockEP11DBusMessagei+0x1f0): undefined reference to `dbus_message_type_to_string'
/usr/lib/gcc/aarch64-unknown-linux-gnu/14/../../../../aarch64-unknown-linux-gnu/bin/ld: /var/tmp/portage/dev-qt/qtwebengine-6.8.2-r1/work/qtwebengine-everywhere-src-6.8.2_build/src/core/RelWithDebInfo/aarch64/obj/dbus/dbus/bus.o: in function `dbus::Bus::TryRegisterFallback(dbus::ObjectPath const&, DBusObjectPathVTable const*, void*, dbus::Error*)':
bus.cc:(.text._ZN4dbus3Bus19TryRegisterFallbackERKNS_10ObjectPathEPK20DBusObjectPathVTablePvPNS_5ErrorE+0x4): undefined reference to `dbus_connection_try_register_fallback'
/usr/lib/gcc/aarch64-unknown-linux-gnu/14/../../../../aarch64-unknown-linux-gnu/bin/ld: bus.cc:(.text._ZN4dbus3Bus19TryRegisterFallbackERKNS_10ObjectPathEPK20DBusObjectPathVTablePvPNS_5ErrorE+0x8): undefined reference to `dbus_connection_try_register_fallback'
/usr/lib/gcc/aarch64-unknown-linux-gnu/14/../../../../aarch64-unknown-linux-gnu/bin/ld: /var/tmp/portage/dev-qt/qtwebengine-6.8.2-r1/work/qtwebengine-everywhere-src-6.8.2_build/src/core/RelWithDebInfo/aarch64/obj/dbus/dbus/message.o: in function `dbus::MethodCall::MethodCall(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
message.cc:(.text._ZN4dbus10MethodCallC2ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES8_+0x74): undefined reference to `dbus_message_set_member'
/usr/lib/gcc/aarch64-unknown-linux-gnu/14/../../../../aarch64-unknown-linux-gnu/bin/ld: /var/tmp/portage/dev-qt/qtwebengine-6.8.2-r1/work/qtwebengine-everywhere-src-6.8.2_build/src/core/RelWithDebInfo/aarch64/obj/dbus/dbus/message.o: in function `dbus::Signal::Signal(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&)':
message.cc:(.text._ZN4dbus6SignalC2ERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEES8_+0x74): undefined reference to `dbus_message_set_member'
/usr/lib/gcc/aarch64-unknown-linux-gnu/14/../../../../aarch64-unknown-linux-gnu/bin/ld: /var/tmp/portage/dev-qt/qtwebengine-6.8.2-r1/work/qtwebengine-everywhere-src-6.8.2_build/src/core/RelWithDebInfo/aarch64/obj/dbus/dbus/message.o: in function `dbus::MessageReader::PopFileDescriptor(base::ScopedGeneric<int, base::internal::ScopedFDCloseTraits>*)':
message.cc:(.text._ZN4dbus13MessageReader17PopFileDescriptorEPN4base13ScopedGenericIiNS1_8internal19ScopedFDCloseTraitsEEE+0x3c): undefined reference to `dbus_get_version'
/usr/lib/gcc/aarch64-unknown-linux-gnu/14/../../../../aarch64-unknown-linux-gnu/bin/ld: /var/tmp/portage/dev-qt/qtwebengine-6.8.2-r1/work/qtwebengine-everywhere-src-6.8.2_build/src/core/RelWithDebInfo/aarch64/obj/dbus/dbus/message.o: in function `dbus::Message::ToStringInternal(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, dbus::MessageReader*)':
message.cc:(.text._ZN4dbus7Message16ToStringInternalERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEEPNS_13MessageReaderE+0x184c): undefined reference to `dbus_get_version'
/usr/lib/gcc/aarch64-unknown-linux-gnu/14/../../../../aarch64-unknown-linux-gnu/bin/ld: /var/tmp/portage/dev-qt/qtwebengine-6.8.2-r1/work/qtwebengine-everywhere-src-6.8.2_build/src/core/RelWithDebInfo/aarch64/obj/dbus/dbus/message.o: in function `dbus::Message::ToString[abi:cxx11]()':
message.cc:(.text._ZN4dbus7Message8ToStringB5cxx11Ev+0x4f4): undefined reference to `dbus_message_get_serial'
/usr/lib/gcc/aarch64-unknown-linux-gnu/14/../../../../aarch64-unknown-linux-gnu/bin/ld: message.cc:(.text._ZN4dbus7Message8ToStringB5cxx11Ev+0x540): undefined reference to `dbus_message_get_reply_serial'
collect2: error: ld returned 1 exit status
ninja: build stopped: subcommand failed.
```

(sorry about .bak file, didn't know it was important)